### PR TITLE
lock toolchain version to nightly-2020-12-07

### DIFF
--- a/.github/workflows/kernel.yaml
+++ b/.github/workflows/kernel.yaml
@@ -22,7 +22,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: nightly-2020-12-07
       - name: Install `rust-src` Rustup Component
         run: rustup component add rust-src
       - name: Run `cargo build`
@@ -38,7 +38,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: nightly-2020-12-07
       - name: Checkout Repository
         uses: actions/checkout@v2
       - name: Install Rustup Components
@@ -64,9 +64,29 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: nightly-2020-12-07
           components: rustfmt
           override: true
       - name: Run `cargo fmt`
         run: cargo fmt --all -- --check
         working-directory: ${{env.working-directory}}
+
+  clippy:
+    name: Clippy
+    env:
+      working-directory: ./kernel
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+      - name: Install Rust Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly-2020-12-07
+          components: clippy, rust-src
+          override: true
+      - name: Run `cargo clippy`
+        run: cargo clippy
+        working-directory: ${{env.working-directory}}
+

--- a/Makefile
+++ b/Makefile
@@ -8,18 +8,21 @@ MAKEFLAGS += --silent
 default: help
 .ONESHELL: # Only applies to all target
 
+## install: Install toolchain dependencies
 install:
-	@rustup override set nightly
+	@rustup override set nightly-2020-12-07
 	@rustup component add rust-src
 	@rustup component add llvm-tools-preview
 	@rustup component add clippy
-	
+
+## fmt: Format codebase using cargo fmt
 fmt:
 	@printf "🔧 Formatting\n"
 	cd $(KERNELDIR)
 	@cargo fmt --all
 	@printf "👍 Done\n"
 
+## kernel_build: Build kernel image
 kernel_build:
 	@printf "🔧 Building kernel binary\n"
 	cd $(KERNELDIR)
@@ -27,12 +30,14 @@ kernel_build:
 	@cargo build
 	@printf "👍 Done\n"
 
+## kernel_test: Run kernel tests
 kernel_test:
 	@printf "🔧 Running kernel tests\n"
 	cd $(KERNELDIR)
 	@cargo test
 	@printf "👍 Done\n"
 
+## kernel_run: Attach QEMU and run kernel
 kernel_run:
 	@printf "🔧 Updating crates\n"
 	cd $(KERNELDIR)
@@ -42,6 +47,6 @@ kernel_run:
 	@printf "👍 Done\n"
 
 help: Makefile
-	@printf "RusticOS, Lightweight OS implementation in Rust\n\n"
-	@printf "For now just run make kernel_build && make kernel_run\n"
-	@printf "Do check out the code at https://github.com/sdslabs/rusticos\n"
+	@printf "\nRusticOS, Lightweight OS implementation in Rust\n\n"
+	@sed -n 's/^##//p' $< | column -t -s ':' |  sed -e 's/^/ /'
+	@printf "\nDo check out the code at https://github.com/sdslabs/rusticos\n\n"

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 bootloader = { version = "0.9.8", features = ["map_physical_memory"]}
 volatile = "0.2.6"
 spin = "0.5.2"
-x86_64 = "0.12.1"
+x86_64 = "0.13.6"
 uart_16550 = "0.2.0"
 pic8259_simple = "0.2.0"
 pc-keyboard = "0.5.0"

--- a/kernel/src/task/executor.rs
+++ b/kernel/src/task/executor.rs
@@ -60,11 +60,11 @@ impl Executor {
     }
 
     fn sleep_if_idle(&self) {
-        use x86_64::instructions::interrupts::{self, enable_interrupts_and_hlt};
+        use x86_64::instructions::interrupts::{self, enable_and_hlt};
 
         interrupts::disable();
         if self.task_queue.is_empty() {
-            enable_interrupts_and_hlt();
+            enable_and_hlt();
         } else {
             interrupts::enable();
         }


### PR DESCRIPTION
Most of the crates require the toolchain version nightly-2020-12-07 to work properly. We will change this further down the line when these packages will be updated or we will fork our own versions.